### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     name: Build (Linux)


### PR DESCRIPTION
Potential fix for [https://github.com/henri2h/PIAF/security/code-scanning/7](https://github.com/henri2h/PIAF/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/main.yml` at the workflow root so it applies to all jobs (including `build-linux`) unless overridden later. The least-privilege setting for this workflow is `contents: read`, which is sufficient for `actions/checkout` and a local build step.

Best single fix (no functional change):  
- Edit `.github/workflows/main.yml`.
- Insert:
  ```yml
  permissions:
    contents: read
  ```
  directly after the `on:` trigger section and before `jobs:` (or equivalently near the top-level keys).  
- No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
